### PR TITLE
Improve mobile editing support and project metadata

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -231,8 +231,16 @@
 
   /* Simplified cursor to clean "+" with subtle corners, removed glow effects */
   /* Redesigned cursor as simple "+" crosshair with minimal tech styling */
-  * {
-    cursor: none !important;
+  @media (pointer: fine) {
+    * {
+      cursor: none !important;
+    }
+  }
+
+  @media (pointer: coarse) {
+    .tech-cursor {
+      display: none !important;
+    }
   }
 
   .tech-cursor {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -238,16 +238,22 @@ export default function TechDashboardPortfolio() {
   }
 
   const handleSaveProject = (project: Project) => {
+    const normalizedProject: Project = {
+      ...project,
+      githubUrl:
+        project.githubUrl && project.githubUrl.trim().length > 0 ? project.githubUrl.trim() : undefined,
+    }
+
     applyContentUpdate((previous) => {
       const updatedCategories = previous.projectCategories.map((category, index) => {
         if (editingProject && index === editingProject.categoryIndex) {
           const projects = [...category.projects]
-          projects[editingProject.projectIndex] = project
+          projects[editingProject.projectIndex] = normalizedProject
           return { ...category, projects }
         }
 
         if (!editingProject && index === activeCategoryIndex) {
-          return { ...category, projects: [...category.projects, project] }
+          return { ...category, projects: [...category.projects, normalizedProject] }
         }
 
         return category
@@ -291,6 +297,13 @@ export default function TechDashboardPortfolio() {
     }))
   }
 
+  const updateLastDeployment = (value: string) => {
+    applyContentUpdate((previous) => ({
+      ...previous,
+      lastDeployment: value,
+    }))
+  }
+
   const updateSkills = (field: keyof PortfolioContent["skillsData"], skills: string[]) => {
     applyContentUpdate((previous) => ({
       ...previous,
@@ -298,7 +311,8 @@ export default function TechDashboardPortfolio() {
     }))
   }
 
-  const { profileData, aboutStats, systemStatus, experienceLog, skillsData, projectCategories, customColor } = content
+  const { profileData, aboutStats, systemStatus, lastDeployment, experienceLog, skillsData, projectCategories, customColor } =
+    content
   const projectCategoryCount = projectCategories.length
 
   useEffect(() => {
@@ -599,7 +613,13 @@ export default function TechDashboardPortfolio() {
               </div>
               <div className="mt-4 sm:mt-6 p-2 sm:p-3 bg-primary/10 border border-primary/30 text-[10px] sm:text-xs font-mono">
                 <p className="text-primary mb-1">{">"} LAST_DEPLOYMENT:</p>
-                <p className="text-muted-foreground">2024-03-15 14:32:07 UTC</p>
+                <EditableText
+                  value={lastDeployment}
+                  onChange={updateLastDeployment}
+                  isEditorMode={isEditorMode}
+                  className="text-muted-foreground"
+                  as="p"
+                />
                 <p className="text-primary mt-2">{">"} BUILD_STATUS:</p>
                 <p className="text-primary">SUCCESS ✓</p>
               </div>
@@ -879,7 +899,7 @@ function ExperienceItem({
       {editable && onDelete && (
         <button
           onClick={onDelete}
-          className="absolute -top-2 right-0 opacity-0 group-hover:opacity-100 transition-opacity p-1 bg-card border border-destructive/50 hover:border-destructive cursor-pointer"
+          className="absolute -top-2 right-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity p-1 bg-card border border-destructive/50 hover:border-destructive cursor-pointer"
           title="Delete Experience"
         >
           <Trash2 className="w-3 h-3 text-destructive" />
@@ -967,6 +987,7 @@ function ProjectCard({
   description,
   status,
   metrics,
+  githubUrl,
   isEditorMode,
   onEdit,
   onDelete,
@@ -984,7 +1005,7 @@ function ProjectCard({
   return (
     <Card className="p-3 sm:p-5 bg-card border border-primary/20 hover:border-primary transition-colors relative group">
       {isEditorMode && (
-        <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="absolute top-2 right-2 flex gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
           <button
             onClick={onEdit}
             className="p-1.5 bg-card border border-primary/50 hover:border-primary cursor-pointer"
@@ -1019,6 +1040,18 @@ function ProjectCard({
           </div>
         ))}
       </div>
+      {githubUrl && (
+        <a
+          href={githubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-2 text-xs sm:text-sm font-mono text-primary hover:text-primary/80 transition-colors"
+          title="View GitHub repository"
+        >
+          <Github className="w-4 h-4" />
+          VIEW_REPOSITORY
+        </a>
+      )}
     </Card>
   )
 }
@@ -1083,7 +1116,7 @@ function SkillCategory({
                 />
                 <button
                   onClick={() => handleRemoveSkill(index)}
-                  className="opacity-0 group-hover:opacity-100 p-0.5 border border-destructive/50 hover:border-destructive cursor-pointer"
+                  className="opacity-100 md:opacity-0 md:group-hover:opacity-100 p-0.5 border border-destructive/50 hover:border-destructive cursor-pointer"
                   title="Remove Skill"
                 >
                   <Trash2 className="w-2.5 h-2.5 text-destructive" />

--- a/components/project-form.tsx
+++ b/components/project-form.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -17,14 +17,31 @@ interface ProjectFormProps {
 }
 
 export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
-  const [formData, setFormData] = useState<Project>(
-    project || {
-      title: "",
-      description: "",
-      status: "DEVELOPMENT",
-      metrics: {},
-    },
+  const [formData, setFormData] = useState<Project>(() =>
+    project
+      ? { ...project, metrics: { ...project.metrics } }
+      : {
+          title: "",
+          description: "",
+          status: "DEVELOPMENT",
+          metrics: {},
+          githubUrl: undefined,
+        },
   )
+
+  useEffect(() => {
+    setFormData(
+      project
+        ? { ...project, metrics: { ...project.metrics } }
+        : {
+            title: "",
+            description: "",
+            status: "DEVELOPMENT",
+            metrics: {},
+            githubUrl: undefined,
+          },
+    )
+  }, [project])
 
   const [metricKey, setMetricKey] = useState("")
   const [metricValue, setMetricValue] = useState("")
@@ -32,7 +49,13 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (formData.title && formData.description) {
-      onSave(formData)
+      const trimmedGithub = formData.githubUrl?.trim()
+      const projectToSave: Project = {
+        ...formData,
+        githubUrl: trimmedGithub ? trimmedGithub : undefined,
+      }
+
+      onSave(projectToSave)
     }
   }
 
@@ -89,6 +112,21 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
               className="w-full bg-background border border-primary/50 focus:border-primary font-mono p-2 min-h-[100px] text-sm"
               placeholder="Describe your project..."
               required
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="githubUrl" className="text-sm font-mono text-muted-foreground mb-2 block">
+              GITHUB_REPOSITORY <span className="text-xs text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="githubUrl"
+              type="url"
+              value={formData.githubUrl ?? ""}
+              onChange={(e) => setFormData({ ...formData, githubUrl: e.target.value })}
+              className="bg-background border-primary/50 focus:border-primary font-mono"
+              placeholder="https://github.com/username/repository"
+              inputMode="url"
             />
           </div>
 

--- a/components/tech-cursor.tsx
+++ b/components/tech-cursor.tsx
@@ -5,8 +5,43 @@ import { useEffect, useState } from "react"
 export function TechCursor() {
   const [position, setPosition] = useState({ x: 0, y: 0 })
   const [isVisible, setIsVisible] = useState(false)
+  const [isPointerFine, setIsPointerFine] = useState(false)
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia("(pointer: fine)")
+
+    const updatePointerMode = (event: MediaQueryList | MediaQueryListEvent) => {
+      const matches = "matches" in event ? event.matches : mediaQuery.matches
+      setIsPointerFine(matches)
+      if (!matches) {
+        setIsVisible(false)
+      }
+    }
+
+    updatePointerMode(mediaQuery)
+
+    const listener = (event: MediaQueryListEvent) => updatePointerMode(event)
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", listener)
+    } else {
+      mediaQuery.addListener(listener)
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", listener)
+      } else {
+        mediaQuery.removeListener(listener)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isPointerFine) {
+      return undefined
+    }
+
     const handleMouseMove = (e: MouseEvent) => {
       setPosition({ x: e.clientX, y: e.clientY })
       setIsVisible(true)
@@ -23,9 +58,9 @@ export function TechCursor() {
       document.removeEventListener("mousemove", handleMouseMove)
       document.removeEventListener("mouseleave", handleMouseLeave)
     }
-  }, [])
+  }, [isPointerFine])
 
-  if (!isVisible) return null
+  if (!isPointerFine || !isVisible) return null
 
   return (
     <div

--- a/lib/default-content.ts
+++ b/lib/default-content.ts
@@ -7,6 +7,7 @@ export interface Project {
   description: string
   status: ProjectStatus
   metrics: Record<string, string>
+  githubUrl?: string
 }
 
 export type ProjectVisual = "brain" | "sphere" | "engine"
@@ -83,6 +84,7 @@ export interface PortfolioContent {
   profileData: ProfileData
   aboutStats: AboutStats
   systemStatus: SystemStatus
+  lastDeployment: string
   experienceLog: ExperienceEntry[]
   skillsData: SkillsData
   projectCategories: ProjectCategory[]
@@ -136,11 +138,13 @@ export const portfolioContentSchema = z.object({
             description: z.string(),
             status: z.union([z.literal("PRODUCTION"), z.literal("BETA"), z.literal("DEVELOPMENT")]),
             metrics: z.record(z.string()),
+            githubUrl: z.string().url().optional(),
           }),
         ),
       }),
     )
     .min(1),
+  lastDeployment: z.string(),
   customColor: z.object({
     h: z.number(),
     s: z.number(),
@@ -159,6 +163,7 @@ export function withDefaultCustomColor(content: PersistedPortfolioContent): Port
   return {
     ...content,
     experienceLog: content.experienceLog ?? defaults.experienceLog,
+    lastDeployment: content.lastDeployment ?? defaults.lastDeployment,
     customColor: defaults.customColor,
   }
 }
@@ -181,6 +186,7 @@ export const defaultContent: PortfolioContent = {
     devops: 82,
     database: 90,
   },
+  lastDeployment: "2024-03-15 14:32:07 UTC",
   experienceLog: defaultExperienceLog,
   skillsData: {
     frontend: ["React", "Next.js", "TypeScript", "Tailwind CSS", "Vue.js"],
@@ -198,6 +204,7 @@ export const defaultContent: PortfolioContent = {
           description: "Real-time ML model monitoring system with predictive analytics and automated alerting.",
           status: "PRODUCTION",
           metrics: { users: "15K", uptime: "99.9%" },
+          githubUrl: "https://github.com/johndoe/neural-network-dashboard",
         },
         {
           title: "NLP_SENTIMENT_ANALYZER",
@@ -242,6 +249,7 @@ export const defaultContent: PortfolioContent = {
           description: "Scalable API gateway with rate limiting, authentication, and request transformation.",
           status: "BETA",
           metrics: { endpoints: "200+", throughput: "10K/s" },
+          githubUrl: "https://github.com/johndoe/api-gateway-v3",
         },
         {
           title: "MONITORING_SUITE",


### PR DESCRIPTION
## Summary
- hide the tech cursor on touch devices while keeping the desktop cursor customization scoped to fine pointers
- make the LAST_DEPLOYMENT field editable/persisted and expose editor affordances on mobile displays
- add optional GitHub repository metadata to projects, updating the form, schema, and project card rendering

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e1206bfc00832db4eba908861c3a49