### PR TITLE
Implement theme-specific accents and loading skeletons

### DIFF
--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,5 @@
+import { cn } from "@/lib/utils"
+
+export function Skeleton({ className }: { className?: string }) {
+  return <div className={cn("animate-pulse rounded bg-muted/30", className)} />
+}


### PR DESCRIPTION
## Summary
- split the default accent color so dark mode keeps the existing hue and light mode uses hsl(245, 100%, 37%)
- update the dashboard to derive runtime colors from theme-aware defaults and expose a reusable Skeleton primitive
- replace default-content fallbacks during fetches with section skeletons plus an inline retry for failed loads

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e12530dbd0832daf126609a15df901