### PR TITLE
feat: add editable education section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ import {
   Plus,
   Edit,
   Trash2,
+  GraduationCap,
 } from "lucide-react"
 import { ParticleBrain } from "@/components/particle-brain"
 import { ParticleSphere } from "@/components/particle-sphere"
@@ -37,6 +38,7 @@ import { TechCursor } from "@/components/tech-cursor"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   cloneDefaultContent,
+  type EducationEntry,
   type ExperienceEntry,
   type PortfolioContent,
   type Project,
@@ -61,14 +63,18 @@ type AuthResult = { success: boolean; error?: string }
 
 export default function TechDashboardPortfolio() {
   const [time, setTime] = useState(new Date())
-  const [activeSection, setActiveSection] = useState<"ALL" | "ABOUT" | "EXPERIENCE" | "PROJECTS" | "SKILLS">("ALL")
+  const [activeSection, setActiveSection] = useState<
+    "ALL" | "ABOUT" | "EXPERIENCE" | "EDUCATION" | "PROJECTS" | "SKILLS"
+  >("ALL")
   const [activeCategoryIndex, setActiveCategoryIndex] = useState(0)
   const [theme, setTheme] = useState<"dark" | "light">("dark")
   const [isEditorMode, setIsEditorMode] = useState(false)
   const [showAuthModal, setShowAuthModal] = useState(false)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [showProjectForm, setShowProjectForm] = useState(false)
+  const [showEducationForm, setShowEducationForm] = useState(false)
   const [editingProject, setEditingProject] = useState<EditingProjectState>(null)
+  const [editingEducationIndex, setEditingEducationIndex] = useState<number | null>(null)
   const [content, setContent] = useState<PortfolioContent | null>(null)
   const [isContentLoading, setIsContentLoading] = useState(true)
   const [contentError, setContentError] = useState<string | null>(null)
@@ -300,6 +306,44 @@ export default function TechDashboardPortfolio() {
     setEditingProject(null)
   }
 
+  const handleAddEducation = () => {
+    setEditingEducationIndex(null)
+    setShowEducationForm(true)
+  }
+
+  const handleEditEducation = (index: number) => {
+    setEditingEducationIndex(index)
+    setShowEducationForm(true)
+  }
+
+  const handleDeleteEducation = (index: number) => {
+    if (!window.confirm("Are you sure you want to delete this education entry?")) {
+      return
+    }
+
+    applyContentUpdate((previous) => ({
+      ...previous,
+      educationLog: (previous.educationLog ?? []).filter((_, idx) => idx !== index),
+    }))
+  }
+
+  const handleSaveEducation = (education: EducationEntry) => {
+    applyContentUpdate((previous) => {
+      const educationLog = [...(previous.educationLog ?? [])]
+
+      if (editingEducationIndex !== null) {
+        educationLog[editingEducationIndex] = education
+      } else {
+        educationLog.push(education)
+      }
+
+      return { ...previous, educationLog }
+    })
+
+    setShowEducationForm(false)
+    setEditingEducationIndex(null)
+  }
+
   const handleColorChange = (h: number, s: number, l: number) => {
     applyContentUpdate(
       (previous) => ({
@@ -450,6 +494,16 @@ export default function TechDashboardPortfolio() {
           }}
         />
       )}
+      {showEducationForm && content && (
+        <EducationForm
+          education={editingEducationIndex !== null ? content.educationLog[editingEducationIndex] : undefined}
+          onSave={handleSaveEducation}
+          onCancel={() => {
+            setShowEducationForm(false)
+            setEditingEducationIndex(null)
+          }}
+        />
+      )}
 
       <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-50 relative">
         <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4">
@@ -526,7 +580,7 @@ export default function TechDashboardPortfolio() {
 
       <main className="container mx-auto px-3 sm:px-4 py-4 sm:py-8 relative z-10">
         <div className="flex gap-1.5 sm:gap-2 mb-4 sm:mb-8 overflow-x-auto pb-2 -mx-3 px-3 sm:mx-0 sm:px-0">
-          {["ALL", "ABOUT", "EXPERIENCE", "PROJECTS", "SKILLS"].map((section) => (
+          {["ALL", "ABOUT", "EXPERIENCE", "EDUCATION", "PROJECTS", "SKILLS"].map((section) => (
             <Button
               key={section}
               variant={activeSection === section ? "default" : "outline"}
@@ -722,6 +776,46 @@ export default function TechDashboardPortfolio() {
             </Card>
           ) : (
             <ExperienceSectionSkeleton />
+          ))}
+
+        {shouldShowSection("EDUCATION") &&
+          (content ? (
+            <Card className="p-4 sm:p-6 bg-card border border-primary/20 mb-4 sm:mb-8">
+              <div className="flex items-center justify-between mb-4 sm:mb-6">
+                <h3 className="text-base sm:text-lg font-mono text-primary flex items-center gap-2">
+                  <GraduationCap className="w-4 h-4 sm:w-5 sm:h-5" />
+                  EDUCATION_TIMELINE
+                </h3>
+                {isEditorMode && (
+                  <button
+                    onClick={handleAddEducation}
+                    className="flex items-center gap-2 px-3 py-2 border border-primary/50 bg-card hover:border-primary cursor-pointer"
+                  >
+                    <Plus className="w-4 h-4 text-primary" />
+                    <span className="text-xs font-mono text-primary">NEW_RECORD</span>
+                  </button>
+                )}
+              </div>
+              {content.educationLog.length > 0 ? (
+                <div className="space-y-4 sm:space-y-6">
+                  {content.educationLog.map((entry, index) => (
+                    <EducationItem
+                      key={`${entry.degree}-${entry.year}-${index}`}
+                      entry={entry}
+                      isEditorMode={isEditorMode}
+                      onEdit={() => handleEditEducation(index)}
+                      onDelete={() => handleDeleteEducation(index)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs sm:text-sm text-muted-foreground font-mono">
+                  No education records yet. Use NEW_RECORD to add your academic milestones.
+                </p>
+              )}
+            </Card>
+          ) : (
+            <EducationSectionSkeleton />
           ))}
 
         {shouldShowSection("PROJECTS") &&
@@ -1048,6 +1142,246 @@ function ExperienceItem({
   )
 }
 
+function EducationItem({
+  entry,
+  isEditorMode,
+  onEdit,
+  onDelete,
+}: {
+  entry: EducationEntry
+  isEditorMode?: boolean
+  onEdit?: () => void
+  onDelete?: () => void
+}) {
+  const { year, degree, institution, description, tags } = entry
+
+  return (
+    <div className="relative group">
+      <div className="flex gap-3 sm:gap-4">
+        <div className="flex flex-col items-center flex-shrink-0">
+          <div className="w-3 h-3 sm:w-4 sm:h-4 border-2 border-primary bg-background rounded-full" />
+          <div className="w-0.5 flex-1 bg-primary/30 mt-2" />
+        </div>
+
+        <div className="flex-1 pb-4">
+          <div className="flex items-start justify-between gap-2 mb-2">
+            <div className="flex-1">
+              <p className="text-[10px] sm:text-xs font-mono text-primary mb-1">{year}</p>
+              <h4 className="text-base sm:text-lg font-bold text-foreground mb-1">{degree}</h4>
+              <p className="text-xs sm:text-sm text-muted-foreground mb-2">{institution}</p>
+            </div>
+            {isEditorMode && (
+              <div className="flex gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                <button
+                  onClick={onEdit}
+                  className="p-1.5 bg-card border border-primary/50 hover:border-primary cursor-pointer"
+                  title="Edit Education"
+                >
+                  <Edit className="w-3 h-3 text-primary" />
+                </button>
+                <button
+                  onClick={onDelete}
+                  className="p-1.5 bg-card border border-destructive/50 hover:border-destructive cursor-pointer"
+                  title="Delete Education"
+                >
+                  <Trash2 className="w-3 h-3 text-destructive" />
+                </button>
+              </div>
+            )}
+          </div>
+          {description.trim().length > 0 && (
+            <p className="text-xs sm:text-sm text-foreground mb-3 leading-relaxed">{description}</p>
+          )}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 sm:gap-2">
+              {tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className="text-[10px] sm:text-xs font-mono border-primary/50 text-primary"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function EducationForm({
+  education,
+  onSave,
+  onCancel,
+}: {
+  education?: EducationEntry
+  onSave: (education: EducationEntry) => void
+  onCancel: () => void
+}) {
+  const emptyEducation: EducationEntry = useMemo(
+    () => ({
+      year: "",
+      degree: "",
+      institution: "",
+      description: "",
+      tags: [],
+    }),
+    [],
+  )
+
+  const [formData, setFormData] = useState<EducationEntry>(education ?? emptyEducation)
+  const [tagInput, setTagInput] = useState("")
+
+  useEffect(() => {
+    setFormData(education ?? emptyEducation)
+    setTagInput("")
+  }, [education, emptyEducation])
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (formData.year.trim() && formData.degree.trim() && formData.institution.trim()) {
+      onSave({
+        ...formData,
+        year: formData.year.trim(),
+        degree: formData.degree.trim(),
+        institution: formData.institution.trim(),
+        description: formData.description.trim(),
+        tags: formData.tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0),
+      })
+    }
+  }
+
+  const handleAddTag = () => {
+    const normalized = tagInput.trim()
+    if (!normalized || formData.tags.includes(normalized)) {
+      return
+    }
+
+    setFormData({ ...formData, tags: [...formData.tags, normalized] })
+    setTagInput("")
+  }
+
+  const handleRemoveTag = (tag: string) => {
+    setFormData({ ...formData, tags: formData.tags.filter((existing) => existing !== tag) })
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+      <Card className="w-full max-w-2xl max-h-[90vh] overflow-y-auto bg-card border-2 border-primary p-4 sm:p-6">
+        <h3 className="text-lg sm:text-xl font-mono text-primary mb-4 sm:mb-6 flex items-center gap-2">
+          <GraduationCap className="w-5 h-5" />
+          {education ? "EDIT_EDUCATION" : "ADD_EDUCATION"}
+        </h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-mono text-muted-foreground mb-2">YEAR_RANGE</label>
+            <input
+              type="text"
+              value={formData.year}
+              onChange={(event) => setFormData({ ...formData, year: event.target.value })}
+              placeholder="e.g., 2018 - 2022"
+              className="w-full bg-background border border-primary/50 px-3 py-2 text-sm font-mono text-foreground focus:border-primary outline-none"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-mono text-muted-foreground mb-2">DEGREE</label>
+            <input
+              type="text"
+              value={formData.degree}
+              onChange={(event) => setFormData({ ...formData, degree: event.target.value })}
+              placeholder="e.g., B.S. COMPUTER_SCIENCE"
+              className="w-full bg-background border border-primary/50 px-3 py-2 text-sm font-mono text-foreground focus:border-primary outline-none"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-mono text-muted-foreground mb-2">INSTITUTION</label>
+            <input
+              type="text"
+              value={formData.institution}
+              onChange={(event) => setFormData({ ...formData, institution: event.target.value })}
+              placeholder="e.g., Tech University"
+              className="w-full bg-background border border-primary/50 px-3 py-2 text-sm font-mono text-foreground focus:border-primary outline-none"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-mono text-muted-foreground mb-2">DESCRIPTION</label>
+            <textarea
+              value={formData.description}
+              onChange={(event) => setFormData({ ...formData, description: event.target.value })}
+              placeholder="Brief description of your education..."
+              className="w-full bg-background border border-primary/50 px-3 py-2 text-sm font-mono text-foreground focus:border-primary outline-none min-h-[100px] resize-y"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-mono text-muted-foreground mb-2">TAGS</label>
+            <div className="flex gap-2 mb-2">
+              <input
+                type="text"
+                value={tagInput}
+                onChange={(event) => setTagInput(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault()
+                    handleAddTag()
+                  }
+                }}
+                placeholder="Add a tag..."
+                className="flex-1 bg-background border border-primary/50 px-3 py-2 text-sm font-mono text-foreground focus:border-primary outline-none"
+              />
+              <Button
+                type="button"
+                onClick={handleAddTag}
+                variant="outline"
+                className="bg-transparent border-primary/50 hover:border-primary cursor-pointer"
+              >
+                <Plus className="w-4 h-4" />
+              </Button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {formData.tags.map((tag) => (
+                <Badge
+                  key={tag}
+                  variant="outline"
+                  className="text-xs font-mono border-primary/50 text-primary flex items-center gap-1"
+                >
+                  <span>{tag}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveTag(tag)}
+                    className="border border-destructive/50 hover:border-destructive px-1 py-0.5 cursor-pointer text-[10px] sm:text-xs leading-none"
+                    title="Remove Tag"
+                  >
+                    ×
+                  </button>
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2 pt-4">
+            <Button type="submit" className="flex-1 font-mono cursor-pointer">
+              SAVE
+            </Button>
+            <Button
+              type="button"
+              onClick={onCancel}
+              variant="outline"
+              className="flex-1 font-mono bg-transparent cursor-pointer"
+            >
+              CANCEL
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  )
+}
+
 function ProjectCard({
   title,
   description,
@@ -1265,6 +1599,37 @@ function ExperienceSectionSkeleton() {
               <Skeleton className="h-6 w-16" />
               <Skeleton className="h-6 w-16" />
               <Skeleton className="h-6 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+function EducationSectionSkeleton() {
+  return (
+    <Card className="p-4 sm:p-6 bg-card border border-primary/20 mb-4 sm:mb-8">
+      <div className="flex items-center justify-between mb-4 sm:mb-6">
+        <Skeleton className="h-6 sm:h-7 w-48" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <div className="space-y-4 sm:space-y-6">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <div key={index} className="flex gap-3 sm:gap-4">
+            <div className="flex flex-col items-center flex-shrink-0">
+              <Skeleton className="h-4 w-4 rounded-full" />
+              <Skeleton className="h-16 w-1" />
+            </div>
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-5 w-52" />
+              <Skeleton className="h-3 w-40" />
+              <Skeleton className="h-12 w-full" />
+              <div className="flex gap-2">
+                <Skeleton className="h-6 w-16" />
+                <Skeleton className="h-6 w-16" />
+              </div>
             </div>
           </div>
         ))}

--- a/lib/default-content.ts
+++ b/lib/default-content.ts
@@ -47,6 +47,14 @@ export interface ExperienceEntry {
   tags: string[]
 }
 
+export interface EducationEntry {
+  year: string
+  degree: string
+  institution: string
+  description: string
+  tags: string[]
+}
+
 const defaultExperienceLog: ExperienceEntry[] = [
   {
     year: "2021 - PRESENT",
@@ -74,6 +82,25 @@ const defaultExperienceLog: ExperienceEntry[] = [
   },
 ]
 
+const defaultEducationLog: EducationEntry[] = [
+  {
+    year: "2016 - 2018",
+    degree: "M.S. SOFTWARE_ENGINEERING",
+    institution: "Global Tech University",
+    description:
+      "Focused on distributed systems, cloud-native architectures, and advanced software design patterns.",
+    tags: ["Distributed Systems", "Cloud Architecture", "Leadership"],
+  },
+  {
+    year: "2012 - 2016",
+    degree: "B.S. COMPUTER_SCIENCE",
+    institution: "Innovation Institute of Technology",
+    description:
+      "Graduated with honors. Specialized in algorithms, data structures, and human-computer interaction.",
+    tags: ["Algorithms", "HCI", "Dean's List"],
+  },
+]
+
 export interface SkillsData {
   frontend: string[]
   backend: string[]
@@ -86,6 +113,7 @@ export interface PortfolioContent {
   systemStatus: SystemStatus
   lastDeployment: string
   experienceLog: ExperienceEntry[]
+  educationLog: EducationEntry[]
   skillsData: SkillsData
   projectCategories: ProjectCategory[]
   customColor: { h: number; s: number; l: number }
@@ -120,6 +148,18 @@ export const portfolioContentSchema = z.object({
       }),
     )
     .default(defaultExperienceLog)
+    .optional(),
+  educationLog: z
+    .array(
+      z.object({
+        year: z.string(),
+        degree: z.string(),
+        institution: z.string(),
+        description: z.string(),
+        tags: z.array(z.string()),
+      }),
+    )
+    .default(defaultEducationLog)
     .optional(),
   skillsData: z.object({
     frontend: z.array(z.string()),
@@ -163,6 +203,7 @@ export function withDefaultCustomColor(content: PersistedPortfolioContent): Port
   return {
     ...content,
     experienceLog: content.experienceLog ?? defaults.experienceLog,
+    educationLog: content.educationLog ?? defaults.educationLog,
     lastDeployment: content.lastDeployment ?? defaults.lastDeployment,
     customColor: defaults.customColor,
   }
@@ -188,6 +229,7 @@ export const defaultContent: PortfolioContent = {
   },
   lastDeployment: "2024-03-15 14:32:07 UTC",
   experienceLog: defaultExperienceLog,
+  educationLog: defaultEducationLog,
   skillsData: {
     frontend: ["React", "Next.js", "TypeScript", "Tailwind CSS", "Vue.js"],
     backend: ["Node.js", "Python", "Go", "PostgreSQL", "Redis"],


### PR DESCRIPTION
## Summary
- extend persisted portfolio schema with an education log and default academic entries
- add an education timeline section with CRUD controls integrated into editor mode
- provide a modal form for editing education entries and a loading skeleton for the new section

## Testing
- npm run lint *(fails: ESLint must be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e12b72949c832d9718e1da231f5b98