### PR TITLE
Fix color picker modal closing on slider interaction

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -648,7 +648,6 @@ export default function TechDashboardPortfolio() {
                 <Skeleton className="h-9 w-9 sm:h-10 sm:w-10 border border-primary/50" />
               ) : (
                 <ColorPicker
-                  key={`${accentColor.h}-${accentColor.s}-${accentColor.l}`}
                   onColorChange={handleColorChange}
                   defaultH={accentColor.h}
                   defaultS={accentColor.s}

--- a/components/color-picker.tsx
+++ b/components/color-picker.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Card } from "@/components/ui/card"
 import { Slider } from "@/components/ui/slider"
 import { Palette } from "lucide-react"
@@ -17,6 +17,12 @@ export function ColorPicker({ onColorChange, defaultH = 25, defaultS = 90, defau
   const [saturation, setSaturation] = useState(defaultS)
   const [lightness, setLightness] = useState(defaultL)
   const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    setHue(defaultH)
+    setSaturation(defaultS)
+    setLightness(defaultL)
+  }, [defaultH, defaultS, defaultL])
 
   const handleHueChange = (value: number[]) => {
     setHue(value[0])


### PR DESCRIPTION
## Summary
- keep the color picker mounted while sliders update by removing the dynamic key
- synchronize the internal slider state with incoming default HSL values so external updates still reflect in the picker

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e1539b0578832db74d5d19a6ef34af