### PR TITLE
Add new project statuses and external link support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -362,6 +362,7 @@ export default function TechDashboardPortfolio() {
     const normalizedProject: Project = {
       ...project,
       githubUrl: project.githubUrl && project.githubUrl.trim().length > 0 ? project.githubUrl.trim() : undefined,
+      projectUrl: project.projectUrl && project.projectUrl.trim().length > 0 ? project.projectUrl.trim() : undefined,
     }
 
     applyContentUpdate((previous) => {

--- a/components/portfolio/projects-section.tsx
+++ b/components/portfolio/projects-section.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { formatMultilineText } from "@/components/editable-text"
-import { Github, ChevronLeft, ChevronRight, Plus, Edit, Trash2 } from "lucide-react"
+import { Github, ChevronLeft, ChevronRight, Plus, Edit, Trash2, Globe } from "lucide-react"
 import { type ProjectCategory, type Project } from "@/lib/default-content"
 
 export type ProjectVisualComponent = React.ComponentType<{
@@ -113,12 +113,14 @@ type ProjectCardProps = {
 }
 
 function ProjectCard({ project, isEditorMode, onEdit, onDelete }: ProjectCardProps) {
-  const { title, description, status, metrics, githubUrl } = project
+  const { title, description, status, metrics, githubUrl, projectUrl } = project
 
   const statusColors = {
     PRODUCTION: "text-primary border-primary",
     BETA: "text-primary/70 border-primary/70",
     DEVELOPMENT: "text-primary/50 border-primary/50",
+    ONGOING: "text-primary/80 border-primary/80",
+    TERMINED: "text-destructive border-destructive/80",
   } as const
 
   return (
@@ -163,17 +165,33 @@ function ProjectCard({ project, isEditorMode, onEdit, onDelete }: ProjectCardPro
           </div>
         ))}
       </div>
-      {githubUrl && (
-        <a
-          href={githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-3 inline-flex items-center gap-2 text-xs sm:text-sm font-mono text-primary hover:text-primary/80 transition-colors"
-          title="View GitHub repository"
-        >
-          <Github className="w-4 h-4" />
-          VIEW_REPOSITORY
-        </a>
+      {(githubUrl || projectUrl) && (
+        <div className="mt-3 flex flex-col gap-2">
+          {githubUrl && (
+            <a
+              href={githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-xs sm:text-sm font-mono text-primary hover:text-primary/80 transition-colors"
+              title="View GitHub repository"
+            >
+              <Github className="w-4 h-4" />
+              VIEW_REPOSITORY
+            </a>
+          )}
+          {projectUrl && (
+            <a
+              href={projectUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-xs sm:text-sm font-mono text-primary hover:text-primary/80 transition-colors"
+              title="Visit project"
+            >
+              <Globe className="w-4 h-4" />
+              VISIT_PROJECT
+            </a>
+          )}
+        </div>
       )}
     </Card>
   )

--- a/components/project-form.tsx
+++ b/components/project-form.tsx
@@ -26,6 +26,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
           status: "DEVELOPMENT",
           metrics: {},
           githubUrl: undefined,
+          projectUrl: undefined,
         },
   )
 
@@ -39,6 +40,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
             status: "DEVELOPMENT",
             metrics: {},
             githubUrl: undefined,
+            projectUrl: undefined,
           },
     )
   }, [project])
@@ -59,9 +61,11 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
     e.preventDefault()
     if (formData.title && formData.description) {
       const trimmedGithub = formData.githubUrl?.trim()
+      const trimmedProjectUrl = formData.projectUrl?.trim()
       const projectToSave: Project = {
         ...formData,
         githubUrl: trimmedGithub ? trimmedGithub : undefined,
+        projectUrl: trimmedProjectUrl ? trimmedProjectUrl : undefined,
       }
 
       onSave(projectToSave)
@@ -141,6 +145,21 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
             </div>
 
             <div>
+              <Label htmlFor="projectUrl" className="text-sm font-mono text-muted-foreground mb-2 block">
+                PROJECT_LINK <span className="text-xs text-muted-foreground">(optional)</span>
+              </Label>
+              <Input
+                id="projectUrl"
+                type="url"
+                value={formData.projectUrl ?? ""}
+                onChange={(e) => setFormData({ ...formData, projectUrl: e.target.value })}
+                className="bg-background border-primary/50 focus:border-primary font-mono"
+                placeholder="https://project.example.com"
+                inputMode="url"
+              />
+            </div>
+
+            <div>
               <Label htmlFor="status" className="text-sm font-mono text-muted-foreground mb-2 block">
                 STATUS
               </Label>
@@ -153,6 +172,8 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
                 <option value="DEVELOPMENT">DEVELOPMENT</option>
                 <option value="BETA">BETA</option>
                 <option value="PRODUCTION">PRODUCTION</option>
+                <option value="ONGOING">ONGOING</option>
+                <option value="TERMINED">TERMINED</option>
               </select>
             </div>
 

--- a/lib/default-content.ts
+++ b/lib/default-content.ts
@@ -2,7 +2,12 @@ import { z } from "zod"
 
 import { DEFAULT_THEME_COLORS, type ThemeMode } from "./theme"
 
-export type ProjectStatus = "PRODUCTION" | "BETA" | "DEVELOPMENT"
+export type ProjectStatus =
+  | "PRODUCTION"
+  | "BETA"
+  | "DEVELOPMENT"
+  | "ONGOING"
+  | "TERMINED"
 
 export interface Project {
   title: string
@@ -10,6 +15,7 @@ export interface Project {
   status: ProjectStatus
   metrics: Record<string, string>
   githubUrl?: string
+  projectUrl?: string
 }
 
 export type ProjectVisual = "brain" | "sphere" | "engine"
@@ -223,9 +229,16 @@ export const portfolioContentSchema = z.object({
           z.object({
             title: z.string(),
             description: z.string(),
-            status: z.union([z.literal("PRODUCTION"), z.literal("BETA"), z.literal("DEVELOPMENT")]),
+            status: z.union([
+              z.literal("PRODUCTION"),
+              z.literal("BETA"),
+              z.literal("DEVELOPMENT"),
+              z.literal("ONGOING"),
+              z.literal("TERMINED"),
+            ]),
             metrics: z.record(z.string()),
             githubUrl: z.string().url().optional(),
+            projectUrl: z.string().url().optional(),
           }),
         ),
       }),
@@ -340,12 +353,14 @@ export const defaultContent: PortfolioContent = {
           status: "PRODUCTION",
           metrics: { users: "15K", uptime: "99.9%" },
           githubUrl: "https://github.com/johndoe/neural-network-dashboard",
+          projectUrl: "https://neural-dashboard.example.com",
         },
         {
           title: "NLP_SENTIMENT_ANALYZER",
           description: "Advanced natural language processing engine for real-time sentiment analysis across multiple languages.",
-          status: "PRODUCTION",
+          status: "ONGOING",
           metrics: { accuracy: "94%", speed: "50ms" },
+          projectUrl: "https://sentiment-analyzer.example.com",
         },
       ],
     },
@@ -359,12 +374,14 @@ export const defaultContent: PortfolioContent = {
           description: "Full-stack e-commerce solution with real-time inventory, payment processing, and analytics dashboard.",
           status: "PRODUCTION",
           metrics: { transactions: "100K+", revenue: "$2M" },
+          projectUrl: "https://commerce-platform.example.com",
         },
         {
           title: "SOCIAL_MEDIA_APP",
           description: "Real-time social networking platform with live messaging, media sharing, and content moderation.",
           status: "BETA",
           metrics: { users: "50K", messages: "1M/day" },
+          projectUrl: "https://beta.social-app.example.com",
         },
       ],
     },
@@ -378,19 +395,22 @@ export const defaultContent: PortfolioContent = {
           description: "High-performance caching layer reducing database load by 85% across microservices.",
           status: "PRODUCTION",
           metrics: { requests: "50M/day", latency: "12ms" },
+          projectUrl: "https://cache-system.example.com",
         },
         {
           title: "API_GATEWAY_v3",
           description: "Scalable API gateway with rate limiting, authentication, and request transformation.",
-          status: "BETA",
+          status: "TERMINED",
           metrics: { endpoints: "200+", throughput: "10K/s" },
           githubUrl: "https://github.com/johndoe/api-gateway-v3",
+          projectUrl: "https://api-gateway.example.com",
         },
         {
           title: "MONITORING_SUITE",
           description: "Comprehensive observability platform with custom metrics, logs, and distributed tracing.",
           status: "DEVELOPMENT",
           metrics: { services: "45", alerts: "120" },
+          projectUrl: "https://monitoring-suite.example.com",
         },
       ],
     },


### PR DESCRIPTION
## Summary
- allow projects to use the new ONGOING and TERMINED statuses throughout the schema, defaults, and UI
- let portfolio projects store an optional external link alongside the existing GitHub URL and surface it in the card view
- extend the project form and default content to capture and persist the new link field

## Testing
- npm run lint *(fails: ESLint must be installed: npm install --save-dev eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b6b60190832d8291daa18a290577