### PR TITLE
Add profile portrait hologram styling and embed image in CV

### DIFF
--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -2,6 +2,7 @@ import { PrintToolbar } from "@/components/cv/print-toolbar"
 import CvCursorVisibility from "@/components/cv-cursor-visibility"
 import type { PortfolioContent, Project } from "@/lib/default-content"
 import { loadPortfolioContent } from "@/lib/portfolio-content"
+import profilePic from "@/app/prof_pic.jpeg"
 
 const CONTACT_EMAIL = "quicksolver02@gmail.com"
 const CONTACT_PHONE = ""
@@ -215,10 +216,33 @@ export default async function CvPage() {
         header.cv-header {
           display: flex;
           justify-content: space-between;
+          align-items: flex-start;
           gap: 16px;
           border-bottom: 1px solid #cbd5f5;
           padding-bottom: 12px;
           text-transform: uppercase;
+        }
+        .cv-header__primary {
+          display: flex;
+          gap: 16px;
+          align-items: flex-start;
+          flex: 1;
+        }
+        .cv-avatar {
+          margin: 0;
+          width: 82px;
+          height: 82px;
+          border-radius: 8px;
+          overflow: hidden;
+          border: 1px solid #cbd5f5;
+          box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+          flex-shrink: 0;
+        }
+        .cv-avatar img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
         }
         .cv-header h1 {
           font-size: 20pt;
@@ -367,14 +391,19 @@ export default async function CvPage() {
       <PrintToolbar />
       <article className="cv-document">
         <header className="cv-header">
-          <div>
-            <h1>{DATA.name}</h1>
-            <p className="title">{DATA.title}</p>
-            <p className="summary-text">{DATA.location}</p>
-            <p className="summary-text">{PIVA}</p>
+          <div className="cv-header__primary">
+            <figure className="cv-avatar">
+              <img src={profilePic.src} alt={`${DATA.name} portrait`} width={164} height={164} />
+            </figure>
+            <div>
+              <h1>{DATA.name}</h1>
+              <p className="title">{DATA.title}</p>
+              <p className="summary-text">{DATA.location}</p>
+              <p className="summary-text">{PIVA}</p>
+            </div>
           </div>
           <div className="contact">
-            
+
             {DATA.phone ? <p>{DATA.phone}</p> : null}
             <ul className="links-list">
               {DATA.links.map((link) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -202,6 +202,119 @@
     }
   }
 
+  .holo-avatar {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--primary) 60%, transparent);
+    background: radial-gradient(
+      120% 120% at 50% 0%,
+      color-mix(in srgb, var(--primary) 35%, transparent) 0%,
+      transparent 70%
+    );
+    transition: border-color 0.4s ease, box-shadow 0.4s ease;
+    box-shadow: 0 0 0 rgba(56, 189, 248, 0.5);
+    isolation: isolate;
+  }
+
+  .holo-avatar::before {
+    content: "";
+    position: absolute;
+    inset: -40%;
+    background: conic-gradient(
+      from 180deg,
+      transparent 0 25%,
+      rgba(125, 211, 252, 0.4) 35%,
+      rgba(56, 189, 248, 0.7) 40%,
+      transparent 60%
+    );
+    mix-blend-mode: screen;
+    opacity: 0.35;
+    animation: hologramPulse 6s ease-in-out infinite;
+    pointer-events: none;
+  }
+
+  .holo-avatar::after {
+    content: "";
+    position: absolute;
+    inset: -150% 0 0 0;
+    background: linear-gradient(
+      180deg,
+      transparent 10%,
+      rgba(56, 189, 248, 0.1) 25%,
+      rgba(125, 211, 252, 0.65) 45%,
+      rgba(14, 165, 233, 0.85) 50%,
+      rgba(125, 211, 252, 0.55) 55%,
+      transparent 70%
+    );
+    animation: hologramScan 4.5s linear infinite;
+    mix-blend-mode: screen;
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  .holo-avatar__image {
+    position: absolute !important;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: saturate(1.35) contrast(1.1) hue-rotate(-4deg);
+    mix-blend-mode: screen;
+  }
+
+  .holo-avatar__grid {
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(rgba(56, 189, 248, 0.2) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(56, 189, 248, 0.2) 1px, transparent 1px);
+    background-size: 12px 12px;
+    mix-blend-mode: screen;
+    opacity: 0.45;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .holo-avatar__line {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    transform: translateX(-50%);
+    background: linear-gradient(180deg, transparent, rgba(125, 211, 252, 0.8), transparent);
+    mix-blend-mode: screen;
+    opacity: 0.6;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .holo-avatar:hover,
+  .holo-avatar:focus-within {
+    border-color: color-mix(in srgb, var(--primary) 80%, transparent);
+    box-shadow: 0 0 24px rgba(56, 189, 248, 0.45);
+  }
+
+  @keyframes hologramScan {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(220%);
+    }
+  }
+
+  @keyframes hologramPulse {
+    0%,
+    100% {
+      opacity: 0.25;
+      transform: rotate(0deg) scale(1);
+    }
+    50% {
+      opacity: 0.45;
+      transform: rotate(6deg) scale(1.05);
+    }
+  }
+
   /* Adding cursor pointer styles for interactive elements */
   button,
   a,

--- a/components/portfolio/about-section.tsx
+++ b/components/portfolio/about-section.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import Image from "next/image"
 import type React from "react"
 
 import {
@@ -14,11 +15,11 @@ import {
   Plus,
 } from "lucide-react"
 
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { EditableText } from "@/components/editable-text"
 import { type PortfolioContent } from "@/lib/default-content"
+import profilePic from "@/app/prof_pic.jpeg"
 
 export type AboutSectionProps = {
   content: PortfolioContent
@@ -46,9 +47,25 @@ export function AboutSection({
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 sm:gap-4 mb-4 sm:mb-8">
       <Card className="lg:col-span-2 p-4 sm:p-6 bg-card border border-primary/20 ">
-        <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-4 mb-4 sm:mb-6">
-          <div className="w-16 h-16 sm:w-20 sm:h-20 bg-primary/20 border-2 border-primary flex items-center justify-center flex-shrink-0">
-            <Code2 className="w-8 h-8 sm:w-10 sm:h-10 text-primary" />
+        <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-6 mb-4 sm:mb-6">
+          <div className="relative flex-shrink-0">
+            <div className="holo-avatar group w-20 h-20 sm:w-32 sm:h-32">
+              <span className="holo-avatar__grid" aria-hidden="true" />
+              <span className="holo-avatar__line" aria-hidden="true" />
+              <Image
+                src={profilePic}
+                alt={`${content.profileData.name}'s profile portrait`}
+                fill
+                priority
+                sizes="(min-width: 640px) 8rem, 5rem"
+                className="holo-avatar__image"
+              />
+            </div>
+            <div
+              className="absolute -inset-1 hidden sm:block rounded-sm border border-primary/60 opacity-70 blur-[1.5px]"
+              aria-hidden="true"
+            />
+            <div className="absolute -inset-2 hidden sm:block bg-primary/20 opacity-30 blur-lg" aria-hidden="true" />
           </div>
           <div className="flex-1 min-w-0">
             <EditableText
@@ -58,13 +75,16 @@ export function AboutSection({
               as="h2"
               className="text-xl sm:text-3xl font-bold mb-1 sm:mb-2 text-foreground"
             />
-            <EditableText
-              value={`> ${content.profileData.title}`}
-              onChange={(value) => onUpdateProfileField("title", value.replace(/^>\s*/, ""))}
-              isEditorMode={isEditorMode}
-              as="p"
-              className="text-primary font-mono text-xs sm:text-sm mb-1 sm:mb-2"
-            />
+            <div className="flex items-center gap-2 mb-1 sm:mb-2 text-primary font-mono text-[10px] sm:text-sm">
+              <Code2 className="w-4 h-4 sm:w-5 sm:h-5" />
+              <EditableText
+                value={`> ${content.profileData.title}`}
+                onChange={(value) => onUpdateProfileField("title", value.replace(/^>\s*/, ""))}
+                isEditorMode={isEditorMode}
+                as="p"
+                className="flex-1"
+              />
+            </div>
             <EditableText
               value={content.profileData.bio}
               onChange={(value) => onUpdateProfileField("bio", value)}


### PR DESCRIPTION
## Summary
- render the new profile portrait in the portfolio About section with a holographic treatment and animated overlays
- add utility styles that create the hologram grid, scan line, and glow effects for the avatar container
- place the raw profile picture in the downloadable CV header with layout adjustments that preserve the document styling

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c0a44a98832dbedff8fc9319bb4a