### PR TITLE
Add profile portrait styling to portfolio and CV

### DIFF
--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -1,7 +1,10 @@
+import Image from "next/image"
+
 import { PrintToolbar } from "@/components/cv/print-toolbar"
 import CvCursorVisibility from "@/components/cv-cursor-visibility"
 import type { PortfolioContent, Project } from "@/lib/default-content"
 import { loadPortfolioContent } from "@/lib/portfolio-content"
+import profilePic from "@/app/prof_pic.jpeg"
 
 const CONTACT_EMAIL = "quicksolver02@gmail.com"
 const CONTACT_PHONE = ""
@@ -219,6 +222,34 @@ export default async function CvPage() {
           border-bottom: 1px solid #cbd5f5;
           padding-bottom: 12px;
           text-transform: uppercase;
+          align-items: flex-start;
+        }
+        .cv-header__identity {
+          flex: 1;
+        }
+        .cv-header__details {
+          display: flex;
+          align-items: flex-start;
+          gap: 12px;
+        }
+        .cv-header__media {
+          position: relative;
+          width: 96px;
+          height: 96px;
+          border: 1px solid #cbd5f5;
+          padding: 4px;
+          background: linear-gradient(135deg, #e2e8f0 0%, #f8fafc 100%);
+          box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+        }
+        .cv-header__media-inner {
+          position: relative;
+          width: 100%;
+          height: 100%;
+          border-radius: 4px;
+          overflow: hidden;
+        }
+        .cv-header__media img {
+          object-fit: cover;
         }
         .cv-header h1 {
           font-size: 20pt;
@@ -367,28 +398,40 @@ export default async function CvPage() {
       <PrintToolbar />
       <article className="cv-document">
         <header className="cv-header">
-          <div>
+          <div className="cv-header__identity">
             <h1>{DATA.name}</h1>
             <p className="title">{DATA.title}</p>
             <p className="summary-text">{DATA.location}</p>
             <p className="summary-text">{PIVA}</p>
           </div>
-          <div className="contact">
-            
-            {DATA.phone ? <p>{DATA.phone}</p> : null}
-            <ul className="links-list">
-              {DATA.links.map((link) => (
-                <li key={link.url}>
-                  <a href={link.url} target="_blank" rel="noreferrer">
-                    {link.label}
-                  </a>:
-                  <a href={link.url} target="_blank" rel="noreferrer">
-                    {" "}{link.url}
-                  </a>
-                </li>
-                
-              ))}
-            </ul>
+          <div className="cv-header__details">
+            <div className="cv-header__media">
+              <div className="cv-header__media-inner">
+                <Image
+                  src={profilePic}
+                  alt={`${DATA.name} portrait`}
+                  fill
+                  sizes="96px"
+                  priority
+                  className="object-cover"
+                />
+              </div>
+            </div>
+            <div className="contact">
+              {DATA.phone ? <p>{DATA.phone}</p> : null}
+              <ul className="links-list">
+                {DATA.links.map((link) => (
+                  <li key={link.url}>
+                    <a href={link.url} target="_blank" rel="noreferrer">
+                      {link.label}
+                    </a>:
+                    <a href={link.url} target="_blank" rel="noreferrer">
+                      {" "}{link.url}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </header>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -321,5 +321,57 @@
     border-right: 1px solid var(--primary);
   }
 
+  .hologram-frame {
+    @apply relative overflow-hidden rounded-xl border border-primary/60 bg-primary/10 backdrop-blur-sm;
+    box-shadow: 0 0 25px rgba(34, 211, 238, 0.25);
+  }
 
+  .hologram-frame::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(
+        rgba(56, 189, 248, 0.12) 1px,
+        transparent 1px
+      ),
+      linear-gradient(90deg, rgba(56, 189, 248, 0.12) 1px, transparent 1px);
+    background-size: 18px 18px;
+    opacity: 0.4;
+    mix-blend-mode: screen;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+
+}
+
+@keyframes hologramGlow {
+  0%,
+  100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 0.65;
+  }
+}
+
+@keyframes hologramScan {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
+.animate-hologram-glow {
+  animation: hologramGlow 4.5s ease-in-out infinite;
+  mix-blend-mode: screen;
+  z-index: 2;
+}
+
+.animate-hologram-scan {
+  animation: hologramScan 3.5s linear infinite;
+  mix-blend-mode: screen;
+  z-index: 3;
 }

--- a/components/portfolio/about-section.tsx
+++ b/components/portfolio/about-section.tsx
@@ -1,10 +1,10 @@
 "use client"
 
+import Image from "next/image"
 import type React from "react"
 
 import {
   Activity,
-  Code2,
   Cpu,
   Database,
   FileDown,
@@ -14,11 +14,11 @@ import {
   Plus,
 } from "lucide-react"
 
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { EditableText } from "@/components/editable-text"
 import { type PortfolioContent } from "@/lib/default-content"
+import profilePic from "@/app/prof_pic.jpeg"
 
 export type AboutSectionProps = {
   content: PortfolioContent
@@ -47,8 +47,22 @@ export function AboutSection({
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 sm:gap-4 mb-4 sm:mb-8">
       <Card className="lg:col-span-2 p-4 sm:p-6 bg-card border border-primary/20 ">
         <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-4 mb-4 sm:mb-6">
-          <div className="w-16 h-16 sm:w-20 sm:h-20 bg-primary/20 border-2 border-primary flex items-center justify-center flex-shrink-0">
-            <Code2 className="w-8 h-8 sm:w-10 sm:h-10 text-primary" />
+          <div className="hologram-frame w-20 h-20 sm:w-28 sm:h-28 flex-shrink-0">
+            <Image
+              src={profilePic}
+              alt={`${content.profileData.name || "Portfolio owner"} portrait`}
+              fill
+              className="object-cover opacity-80 saturate-150"
+              sizes="(max-width: 640px) 80px, 112px"
+              priority
+            />
+            <div className="absolute inset-0 pointer-events-none bg-gradient-to-br from-cyan-400/35 via-transparent to-fuchsia-500/40 mix-blend-screen" />
+            <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_20%_20%,rgba(34,211,238,0.35),transparent_55%),radial-gradient(circle_at_80%_0%,rgba(192,132,252,0.35),transparent_60%)] mix-blend-screen" />
+            <div className="absolute inset-0 pointer-events-none animate-hologram-glow bg-[linear-gradient(120deg,rgba(15,23,42,0)_0%,rgba(56,189,248,0.5)_45%,rgba(15,23,42,0)_100%)]" />
+            <div className="absolute inset-0 pointer-events-none animate-hologram-scan bg-gradient-to-b from-transparent via-cyan-400/40 to-transparent" />
+            <span className="absolute bottom-2 left-2 text-[10px] font-mono tracking-[0.3em] uppercase text-cyan-100 bg-slate-900/70 border border-cyan-300/40 px-2 py-[2px] backdrop-blur-sm">
+              ONLINE
+            </span>
           </div>
           <div className="flex-1 min-w-0">
             <EditableText


### PR DESCRIPTION
## Summary
- feature the new profile portrait in the portfolio with a holographic-styled frame and status badge
- add hologram utility styles and animations to support the portrait overlay effect
- include the portrait in the printable CV header without any visual filters

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c0a44a98832dbedff8fc9319bb4a