### PR TITLE
Add CV visibility toggle for projects

### DIFF
--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -92,13 +92,15 @@ function createCvData(content: PortfolioContent): CvData {
   }))
 
   const projects = content.projectCategories.flatMap((category) =>
-    category.projects.map((project) => ({
-      name: formatLabel(project.title),
-      role: formatLabel(category.name),
-      date: `STATUS: ${formatLabel(project.status)}`,
-      bullets: [formatLabel(project.description), ...projectMetricsToBullets(project)],
-      link: project.githubUrl,
-    })),
+    category.projects
+      .filter((project) => project.showInCv ?? true)
+      .map((project) => ({
+        name: formatLabel(project.title),
+        role: formatLabel(category.name),
+        date: `STATUS: ${formatLabel(project.status)}`,
+        bullets: [formatLabel(project.description), ...projectMetricsToBullets(project)],
+        link: project.githubUrl,
+      })),
   )
 
   const education = content.educationLog.map((entry) => ({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,12 +69,23 @@ const sortEducationEntries = (entries: EducationEntry[] | undefined): EducationE
   return [...entries].sort((first, second) => extractStartYear(second.year) - extractStartYear(first.year))
 }
 
-const calculateProjectCount = (categories: ProjectCategory[] | undefined): number => {
+const calculateProjectCount = (categories: ProjectCategory[]): number =>
+  categories.reduce((total, category) => total + category.projects.length, 0)
+
+const ensureProjectCvVisibility = (
+  categories: ProjectCategory[] | undefined,
+): ProjectCategory[] => {
   if (!categories) {
-    return 0
+    return []
   }
 
-  return categories.reduce((total, category) => total + category.projects.length, 0)
+  return categories.map((category) => ({
+    ...category,
+    projects: category.projects.map((project) => ({
+      ...project,
+      showInCv: project.showInCv ?? true,
+    })),
+  }))
 }
 
 const generateSystemStatusId = (label?: string) => {
@@ -95,12 +106,14 @@ const ensureSystemStatusEntries = (entries: SystemStatus | undefined): SystemSta
 
 const withDerivedContent = (content: PortfolioContent): PortfolioContent => {
   const educationLog = sortEducationEntries(content.educationLog)
-  const projectsCount = calculateProjectCount(content.projectCategories)
+  const projectCategories = ensureProjectCvVisibility(content.projectCategories)
+  const projectsCount = calculateProjectCount(projectCategories)
   const systemStatus = ensureSystemStatusEntries(content.systemStatus)
 
   return {
     ...content,
     educationLog,
+    projectCategories,
     systemStatus,
     aboutStats: {
       ...content.aboutStats,

--- a/components/project-form.tsx
+++ b/components/project-form.tsx
@@ -19,7 +19,7 @@ interface ProjectFormProps {
 export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
   const [formData, setFormData] = useState<Project>(() =>
     project
-      ? { ...project, metrics: { ...project.metrics } }
+      ? { ...project, metrics: { ...project.metrics }, showInCv: project.showInCv ?? true }
       : {
           title: "",
           description: "",
@@ -27,13 +27,14 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
           metrics: {},
           githubUrl: undefined,
           projectUrl: undefined,
+          showInCv: true,
         },
   )
 
   useEffect(() => {
     setFormData(
       project
-        ? { ...project, metrics: { ...project.metrics } }
+        ? { ...project, metrics: { ...project.metrics }, showInCv: project.showInCv ?? true }
         : {
             title: "",
             description: "",
@@ -41,6 +42,7 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
             metrics: {},
             githubUrl: undefined,
             projectUrl: undefined,
+            showInCv: true,
           },
     )
   }, [project])
@@ -175,6 +177,31 @@ export function ProjectForm({ project, onSave, onCancel }: ProjectFormProps) {
                 <option value="ONGOING">ONGOING</option>
                 <option value="TERMINED">TERMINED</option>
               </select>
+            </div>
+
+            <div className="border border-primary/50 bg-background/70 p-3 flex flex-col gap-2">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <Label htmlFor="showInCv" className="text-sm font-mono text-muted-foreground">
+                    SHOW_IN_CV
+                  </Label>
+                  <p className="text-xs font-mono text-muted-foreground/80 mt-1">
+                    Toggle to include this project in the generated CV.
+                  </p>
+                </div>
+                <input
+                  id="showInCv"
+                  type="checkbox"
+                  checked={formData.showInCv}
+                  onChange={(event) =>
+                    setFormData({
+                      ...formData,
+                      showInCv: event.target.checked,
+                    })
+                  }
+                  className="mt-1 h-5 w-5 cursor-pointer accent-primary"
+                />
+              </div>
             </div>
 
             <div>

--- a/lib/default-content.ts
+++ b/lib/default-content.ts
@@ -16,6 +16,7 @@ export interface Project {
   metrics: Record<string, string>
   githubUrl?: string
   projectUrl?: string
+  showInCv: boolean
 }
 
 export type ProjectVisual = "brain" | "sphere" | "engine"
@@ -239,6 +240,7 @@ export const portfolioContentSchema = z.object({
             metrics: z.record(z.string()),
             githubUrl: z.string().url().optional(),
             projectUrl: z.string().url().optional(),
+            showInCv: z.boolean().default(true),
           }),
         ),
       }),
@@ -354,6 +356,7 @@ export const defaultContent: PortfolioContent = {
           metrics: { users: "15K", uptime: "99.9%" },
           githubUrl: "https://github.com/johndoe/neural-network-dashboard",
           projectUrl: "https://neural-dashboard.example.com",
+          showInCv: true,
         },
         {
           title: "NLP_SENTIMENT_ANALYZER",
@@ -361,6 +364,7 @@ export const defaultContent: PortfolioContent = {
           status: "ONGOING",
           metrics: { accuracy: "94%", speed: "50ms" },
           projectUrl: "https://sentiment-analyzer.example.com",
+          showInCv: true,
         },
       ],
     },
@@ -375,6 +379,7 @@ export const defaultContent: PortfolioContent = {
           status: "PRODUCTION",
           metrics: { transactions: "100K+", revenue: "$2M" },
           projectUrl: "https://commerce-platform.example.com",
+          showInCv: true,
         },
         {
           title: "SOCIAL_MEDIA_APP",
@@ -382,6 +387,7 @@ export const defaultContent: PortfolioContent = {
           status: "BETA",
           metrics: { users: "50K", messages: "1M/day" },
           projectUrl: "https://beta.social-app.example.com",
+          showInCv: true,
         },
       ],
     },
@@ -396,6 +402,7 @@ export const defaultContent: PortfolioContent = {
           status: "PRODUCTION",
           metrics: { requests: "50M/day", latency: "12ms" },
           projectUrl: "https://cache-system.example.com",
+          showInCv: true,
         },
         {
           title: "API_GATEWAY_v3",
@@ -404,6 +411,7 @@ export const defaultContent: PortfolioContent = {
           metrics: { endpoints: "200+", throughput: "10K/s" },
           githubUrl: "https://github.com/johndoe/api-gateway-v3",
           projectUrl: "https://api-gateway.example.com",
+          showInCv: true,
         },
         {
           title: "MONITORING_SUITE",
@@ -411,6 +419,7 @@ export const defaultContent: PortfolioContent = {
           status: "DEVELOPMENT",
           metrics: { services: "45", alerts: "120" },
           projectUrl: "https://monitoring-suite.example.com",
+          showInCv: true,
         },
       ],
     },


### PR DESCRIPTION
## Summary
- extend project data with a persistent `showInCv` flag and default values
- surface a "SHOW_IN_CV" checkbox in the project editor and normalize content loading
- filter CV projects so only flagged items appear in the exported resume

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c7ad88d8832db5123ae03da1ed11